### PR TITLE
Improve error messaging.

### DIFF
--- a/stl/error_formatter.py
+++ b/stl/error_formatter.py
@@ -15,6 +15,7 @@
 """Module for formatting parser/syntax errors."""
 
 import abc
+import collections
 import json
 import re
 

--- a/stl/error_formatter.py
+++ b/stl/error_formatter.py
@@ -73,11 +73,11 @@ class Color(object):
     return color + 30
   
   @staticmethod
-    def Background(color):
-      """Converts |color| into its background color code."""
-      if not Color._IsBaseColor(color):
-        raise ValueError('Expected a Color.COLOR constant, found: {}'.format(color))  
-      return color + 40  
+  def Background(color):
+    """Converts |color| into its background color code."""
+    if not Color._IsBaseColor(color):
+      raise ValueError('Expected a Color.COLOR constant, found: {}'.format(color))  
+    return color + 40  
 
 
 class PrettyErrorFormatter(ErrorFormatter):

--- a/stl/error_formatter.py
+++ b/stl/error_formatter.py
@@ -19,13 +19,28 @@ import json
 import re
 
 
+ErrorInfo = collections.namedtuple('ErrorInfo', ['id', 'filename', 'line', 'position', 'message'])
+# Args:
+#   id: An identifier for the type of error.
+#   filename: Name of the file the error occured in.
+#   line: The text of the line the error occured in.
+#   position: An ErrorPosition pointing to where the error occured.
+#   messasge: The human readable message explaining the error
+
+ErrorPosition = collections.namedtuple('ErrorPosiion', ['line', 'start', 'end'])
+# Args:
+#   line: The line number of the error.
+#   start: The position (column) the error starts at in the line (inclusive).
+#   end: The position (column) the error ends at in the line (inclusive).
+
+
 class ErrorFormatter(object):
   """Interface for displaying STL parsing errors."""
   __metaclass__ = abc.ABCMeta
 
   @abc.abstractmethod
   def Format(self, error):
-    """Outputs error_handler.ErrorInfo |error| in a custom format."""
+    """Outputs an ErrorInfo |error| in a custom format."""
     pass
 
 

--- a/stl/error_formatter.py
+++ b/stl/error_formatter.py
@@ -68,7 +68,7 @@ class Color(object):
   @staticmethod
   def Foreground(color):
     """Converts |color| into its foreground color code."""
-    if not Color._IsBaseColor(color)
+    if not Color._IsBaseColor(color):
       raise ValueError('Expected a Color.COLOR constant, found: {}'.format(color))
     return color + 30
   

--- a/stl/error_formatter.py
+++ b/stl/error_formatter.py
@@ -1,0 +1,100 @@
+import abc
+import json
+import re
+
+
+class ErrorFormatter(object):
+  """Interface for displaying STL parsing errors."""
+  __metaclass__ = abc.ABCMeta
+
+  @abc.abstractmethod
+  def format(self, error):
+    """Outputs parser_error.ErrorInfo |error| in a custom format."""
+    pass
+
+
+class JsonErrorFormatter(ErrorFormatter):
+  """Format errors as json objects."""
+
+  def format(self, error):
+    """Format |error| as json."""
+    return json.dumps(error._asdict())
+
+
+class Color(object):
+  """ANSI escape code base color codes.
+
+  For foreground colors, add 30 to the color value.
+  For background colors, add 40 to the color value.
+
+  See https://en.wikipedia.org/wiki/ANSI_escape_code#Colors for more info.
+  """
+
+  BLACK = 0
+  RED = 1
+  GREEN = 2
+  YELLOW = 3
+  BLUE = 4
+  MAGENTA = 5
+  CYAN = 6
+  WHITE = 7
+  DEFAULT = 9
+
+
+class PrettyErrorFormatter(ErrorFormatter):
+  """Pretty-ify errors with colors, highlights, and helpful markings."""
+
+  ERROR_COLOR = Color.RED
+  ANNOTATION_COLOR = Color.YELLOW
+
+  def colorize(self,
+               text,
+               foreground=Color.DEFAULT,
+               background=Color.DEFAULT,
+               bold=True):
+    bold = int(bold)
+    fg_color = foreground + 30
+    bg_color = background + 40
+    return '\x1b[{bold};{fg_color};{bg_color}m{text}\x1b[0m'.format(
+        text=text, bold=bold, fg_color=fg_color, bg_color=bg_color)
+
+  def get_message_line(self, error):
+    """Returns the formatted line with the error message."""
+    file_position = '{}:{}:{}'.format(
+        error.filename, error.position.line, error.position.start)
+    return '{}({}): {}'.format(
+        self.colorize('error', self.ERROR_COLOR),
+        self.colorize(file_position, self.ANNOTATION_COLOR, bold=False),
+        error.message)
+
+  def get_source_line(self, error):
+    """Returns the formatted line from the source that caused the error."""
+    return '{}{}'.format(self.get_line_number_prefix(error), error.line)
+
+  def get_source_annotation_line(self, error):
+    """Returns a line that highlights the original source."""
+    pre_annotation = ' ' * error.position.start
+    annotation = '^' * (error.position.end - error.position.start + 1)
+    return '{}{}'.format(
+        self.get_line_number_prefix(error, show_number=False),
+        self.colorize(pre_annotation + annotation, self.ANNOTATION_COLOR))
+
+  def get_line_number_prefix(self, error, show_number=True):
+    """Returns a prefix to annotate a line with a line number.
+
+    Args:
+      error: The ErrorInfo to get the line number from.
+      show_number: Whether to show or hide the number (hiding the number is
+          useful to get a prefix with the same width and formatting).
+    """
+    prefix_with_number = ' {} | '.format(error.position.line)
+    if show_number:
+      return prefix_with_number
+    return re.sub('\d', ' ', prefix_with_number)
+
+
+  def format(self, error):
+    lines = [self.get_message_line(error),
+             self.get_source_line(error),
+             self.get_source_annotation_line(error),]
+    return '\n'.join(lines)

--- a/stl/error_handler.py
+++ b/stl/error_handler.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2017 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stl/error_handler.py
+++ b/stl/error_handler.py
@@ -16,20 +16,7 @@
 
 import collections
 
-
-ErrorInfo = collections.namedtuple('ErrorInfo', ['id', 'filename', 'line', 'position', 'message'])
-# Args:
-#   id: An identifier for the type of error.
-#   filename: Name of the file the error occured in.
-#   line: The text of the line the error occured in.
-#   position: An ErrorPosition pointing to where the error occured.
-#   messasge: The human readable message explaining the error
-
-ErrorPosition = collections.namedtuple('ErrorPosiion', ['line', 'start', 'end'])
-# Args:
-#   line: The line number of the error.
-#   start: The position (column) the error starts at in the line (inclusive).
-#   end: The position (column) the error ends at in the line (inclusive).
+import error_formatter
 
 
 class ParserErrorHandler(object):
@@ -77,13 +64,13 @@ class ParserErrorHandler(object):
     final_token = parser.symstack[-1]
     error_start_column = self._GetColumn(lexer.lexdata, final_token) - 1
     error_end_column = error_start_column + len(final_token.value) - 1
-    error_position = ErrorPosition(line=lexer.lineno,
-                                   start=error_start_column,
-                                   end=error_end_column)
-    error = ErrorInfo(
+    error_position = error_formatter.ErrorPosition(line=lexer.lineno,
+                                                   start=error_start_column,
+                                                   end=error_end_column)
+    error = error_formatter.ErrorInfo(
         id=0,
         filename=filename,
         line=self._GetLine(lexer.lexdata, final_token),
         position=error_position,
         message='There was a parsing error :(')
-    return self.format(error)
+    return self.Format(error)

--- a/stl/error_handler.py
+++ b/stl/error_handler.py
@@ -1,0 +1,73 @@
+import collections
+
+
+ErrorInfo = collections.namedtuple('ErrorInfo', ['id', 'filename', 'line', 'position', 'message'])
+# Args:
+#   id: An identifier for the type of error.
+#   filename: Name of the file the error occured in.
+#   line: The text of the line the error occured in.
+#   position: An ErrorPosition pointing to where the error occured.
+#   messasge: The human readable message explaining the error
+
+ErrorPosition = collections.namedtuple('ErrorPosiion', ['line', 'start', 'end'])
+# Args:
+#   line: The line number of the error.
+#   start: The position (column) the error starts at in the line (inclusive).
+#   end: The position (column) the error ends at in the line (inclusive).
+
+
+class ParserErrorHandler(object):
+  """Determines the likely cause of a parse error."""
+
+  def __init__(self, error_formatter):
+    """Create a ParserError instance.
+
+    Args:
+      error_formatter: An ErrorFormatter to format the parse errors.
+    """
+    self._formatter = error_formatter
+
+  def format(self, error):
+    """Formats |error| into a string."""
+    return self._formatter.format(error)
+
+  def get_column(self, data, token):
+    """Get the column that |token| starts at within a line in |data|."""
+    last_newline = data.rfind('\n', 0, token.lexpos)
+    if last_newline < 0:
+      last_newline = 0
+    column = token.lexpos - last_newline
+    return column
+
+  def get_line(self, data, token):
+    """Get the line of text that |token| is part of in |data|."""
+    start_line_pos = data.rfind('\n', 0, token.lexpos) + 1
+    end_line_pos = data.find('\n', start_line_pos)
+    return data[start_line_pos:end_line_pos]
+
+
+  def get_error(self, filename, parser, lexer):
+    """Returns a an error string based on the state of |parser| and |lexer".
+
+    Args:
+      filename: The name of the file the error occured in.
+      parser: A PLY parser that has reached the p_error() state.
+      lexer: The PLY lexer that |parser| used to lex.
+
+    Returns:
+      A formatted error string.
+    """
+    print 'SymStack: {}'.format(parser.symstack)
+    final_token = parser.symstack[-1]
+    error_start_column = self.get_column(lexer.lexdata, final_token) - 1
+    error_end_column = error_start_column + len(final_token.value) - 1
+    error_position = ErrorPosition(line=lexer.lineno,
+                                   start=error_start_column,
+                                   end=error_end_column)
+    error = ErrorInfo(
+        id=0,
+        filename=filename,
+        line=self.get_line(lexer.lexdata, final_token),
+        position=error_position,
+        message='There was a parsing error :(')
+    return self.format(error)

--- a/stl/error_handler.py
+++ b/stl/error_handler.py
@@ -1,3 +1,19 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for handling errors from parsing an STL file."""
+
 import collections
 
 
@@ -20,34 +36,34 @@ class ParserErrorHandler(object):
   """Determines the likely cause of a parse error."""
 
   def __init__(self, error_formatter):
-    """Create a ParserError instance.
+    """Creates a ParserError instance.
 
     Args:
       error_formatter: An ErrorFormatter to format the parse errors.
     """
     self._formatter = error_formatter
 
-  def format(self, error):
+  def Format(self, error):
     """Formats |error| into a string."""
-    return self._formatter.format(error)
+    return self._formatter.Format(error)
 
-  def get_column(self, data, token):
-    """Get the column that |token| starts at within a line in |data|."""
+  def _GetColumn(self, data, token):
+    """Gets the column that |token| starts at within a line in |data|."""
     last_newline = data.rfind('\n', 0, token.lexpos)
     if last_newline < 0:
       last_newline = 0
     column = token.lexpos - last_newline
     return column
 
-  def get_line(self, data, token):
-    """Get the line of text that |token| is part of in |data|."""
+  def _GetLine(self, data, token):
+    """Gets the line of text that |token| is part of in |data|."""
     start_line_pos = data.rfind('\n', 0, token.lexpos) + 1
     end_line_pos = data.find('\n', start_line_pos)
     return data[start_line_pos:end_line_pos]
 
 
-  def get_error(self, filename, parser, lexer):
-    """Returns a an error string based on the state of |parser| and |lexer".
+  def GetError(self, filename, parser, lexer):
+    """Returns an error string based on the state of |parser| and |lexer".
 
     Args:
       filename: The name of the file the error occured in.
@@ -59,7 +75,7 @@ class ParserErrorHandler(object):
     """
     print 'SymStack: {}'.format(parser.symstack)
     final_token = parser.symstack[-1]
-    error_start_column = self.get_column(lexer.lexdata, final_token) - 1
+    error_start_column = self._GetColumn(lexer.lexdata, final_token) - 1
     error_end_column = error_start_column + len(final_token.value) - 1
     error_position = ErrorPosition(line=lexer.lineno,
                                    start=error_start_column,
@@ -67,7 +83,7 @@ class ParserErrorHandler(object):
     error = ErrorInfo(
         id=0,
         filename=filename,
-        line=self.get_line(lexer.lexdata, final_token),
+        line=self._GetLine(lexer.lexdata, final_token),
         position=error_position,
         message='There was a parsing error :(')
     return self.format(error)

--- a/stl/error_handler.py
+++ b/stl/error_handler.py
@@ -14,8 +14,6 @@
 
 """Module for handling errors from parsing an STL file."""
 
-import collections
-
 import error_formatter
 
 

--- a/stl/parser.py
+++ b/stl/parser.py
@@ -23,7 +23,6 @@
 # pylint: disable=invalid-name
 # pylint: disable=unused-variable
 
-import collections
 import logging
 import ply.yacc  # pylint: disable=g-bad-import-order
 import pprint
@@ -285,7 +284,7 @@ class StlParser(object):
                  | EVENT NAME params '=' EXTERNAL STRING_LITERAL ';'
                  | EVENT NAME params '=' NAME param_values ';' """
     if len(p) == 8 and stl.base.IsString(p[6]):
-#NAME params = EXTERNAL STRING_LITERAL;
+      #NAME params = EXTERNAL STRING_LITERAL;
       try:
         evt = stl.event.EventFromExternal(p[2], p[6])
       except Exception as e:
@@ -513,7 +512,7 @@ class StlParser(object):
     """reference : NAME
                  | reference '.' NAME"""
     # TODO(byungchul): Support other module's names.
-#TODO(byungchul) : Build FuncGetField or FuncSet here.
+    #TODO(byungchul) : Build FuncGetField or FuncSet here.
     if len(p) == 2:
       p[0] = p[1]
     else:

--- a/stl/parser.py
+++ b/stl/parser.py
@@ -628,7 +628,6 @@ class StlParser(object):
           '[{}] Syntax error: '
           'Reached end of file unexpectantly.'.format(self._filename))
 
-
     print self.error_handler.get_error(
         self._filename, self.parser, self.lexer.lexer)
 


### PR DESCRIPTION
As a first step in improved error messaging, setup a system
for pretty printing the parser errors. And make the error formatters
replaceable. This makes it easy to dump out computer readable formats
for use in build systems and human readable formats for manual use.

Issue: #2
Test: Add syntex error to example/example_base.stl and try to parse it.