### PR TITLE
Fix crash in sprockets/stl/lib.py

### DIFF
--- a/stl/lib.py
+++ b/stl/lib.py
@@ -19,6 +19,8 @@ import json
 import logging
 import random
 
+from google.protobuf import message
+
 import stl.message
 
 
@@ -59,7 +61,7 @@ class ProtobufEncoding(Encoding):
     pbuf = message_type.external()
     try:
       read_len = pbuf.MergeFromString(encoded)
-    except stl.message.DecodeError:
+    except message.DecodeError:
       logging.exception('Could not decode protobuf.')
       return False
     assert read_len == len(encoded)


### PR DESCRIPTION
Unclear how this worked before, maybe python wasn't evaluating the except
clause?

Traceback (most recent call last):
  File "sprockets/test_driver.py", line 349, in <module>
    sys.exit(0 if Main() else 1)
  File "sprockets/test_driver.py", line 345, in Main
    return RunTest(manifest_filename, manifest_arg_dict, args)
  File "sprockets/test_driver.py", line 327, in RunTest
    return TraverseGraph(transitions, states, args)
  File "sprockets/test_driver.py", line 276, in TraverseGraph
    if transition.Run():
  File "sprockets/stl/state.py", line 284, in Run
    if e.Run() is False:
  File "sprockets/stl/base.py", line 671, in Run
    return self.event.Wait(*new_args)
  <snip>
  File "sprockets/stl/message.py", line 329, in Match
    decoded = self.msg.encoding.ParseFromString(encoded, self.msg)
  File "sprockets/stl/lib.py", line 117, in ParseFromString
    base64.b64decode(encoded), message_type)
  File "sprockets/stl/lib.py", line 62, in ParseFromString
    except stl.message.DecodeError:
AttributeError: 'module' object has no attribute 'DecodeError'